### PR TITLE
Fix broken click even handlers for gif objects

### DIFF
--- a/animation6.html
+++ b/animation6.html
@@ -65,9 +65,21 @@
 						</div>
 					</div>
 					<div id="thesun">
-						<div class="thesunclick">
+						<div class="venusContainer">
+							<div class="planet" id="venus">
+								<img src="images/anim_venus_animated.gif" alt="Animated image of planet Venus as part of Solar System animation"/>
+							</div>
+						</div>
+						<div class="mercuryContainer">
+							<div class="planet" id="mercury">
+								<img src="images/anim_mercury_animated.gif" alt="Animated image of planet Mercury as part of Solar System animation"/>
+							</div>
+						</div>
+
+						<div id="sun">
 							<img src="images/anim_sun_animated.gif" alt="Animated image of The Sun as part of Solar System animation"/>
 						</div>
+
 						<div class="star-1 stars"></div>
 						<div class="star-2 stars"></div>
 						<div class="star-3 stars"></div>
@@ -93,17 +105,8 @@
 						<div class="star-23 stars"></div>
 						<div class="star-24 stars"></div>
 						<div class="star-25 stars"></div>
-						<div class="mercuryContainer">
-							<div class="planet" id="mercury">
-								<img src="images/anim_mercury_animated.gif" alt="Animated image of planet Mercury as part of Solar System animation"/>
-							</div>
-                        </div>
-                        <div class="venusContainer">
-							<div class="planet" id="venus">
-								<img src="images/anim_venus_animated.gif" alt="Animated image of planet Venus as part of Solar System animation"/>
-							</div>
-						</div>
 					</div>
+
 					<div id="thesuninvisible" class="hide">
 						<div class="solarsystemtextbox">
 							<p><strong>The Sun</strong></p>
@@ -204,6 +207,57 @@
 							</tr>
 						</table>
 					</div>
+
+					<div id="venusinvisible" class="hide">
+							<div class="solarsystemtextbox">
+								<p><strong>Venus</strong></p>
+								<p>Planet</p>
+								<p>Venus...</p>
+							</div>
+							<br>
+							<table>
+								<tr>
+									<th scope="row"><p>Satellites</p></th>
+									<td><p>0</td>
+									<td><p></p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Volume</p></th>
+									<td><p>6.083 × 10<sup>10</sup> km</p></td>
+									<td><p>0.056 Earths</p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Mass</p></th>
+									<td><p>3.3011 × 10<sup>23</sup> kg</p></td>
+									<td><p>0.555 Earths</p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Radius</p></th>
+									<td><p>2,439.7 km / 1,516 miles</p></td>
+									<td><p>0.3829 Earths</p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Diameter</p></th>
+									<td><p>4880 km</p></td>
+									<td><p></p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Surface area</p></th>
+									<td><p>7.48 × 10<sup>7</sup> km</p></td>
+									<td><p>0.147 Earths</p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Density</p></th>
+									<td><p>5.427 g/cm</p></td>
+									<td><p></p></td>
+								</tr>
+								<tr>
+									<th scope="row"><p>Orbital period</p></th>
+									<td><p></p></td>
+									<td><p>87.969 Earth days / 0.240 846 Earth years</p></td>
+								</tr>
+							</table>
+						</div>
 				</section>
 			</div>
 			<!-- End of Main Section -->

--- a/css/dominicsimpsoncss3.css
+++ b/css/dominicsimpsoncss3.css
@@ -819,6 +819,11 @@ p a:hover, a:focus
 	border-radius: 		228px;
 }
 
+#sun img {
+	position: relative;
+	border-radius: 50%;
+}
+
 /* Planets */
 
 .hide

--- a/scripts/animation6.js
+++ b/scripts/animation6.js
@@ -1,19 +1,13 @@
-$(document).ready(function(){
-
-
-	$('.thesunclick').click(function() {
+$(document).ready(function() {
+	$("#sun").click(function() {
 		$("#thesuninvisible").toggleClass("show");
 	});
-
 
 	$("#mercury").click(function() {
 		$("#mercuryinvisible").toggleClass("show");
 	});
 
-
-
 	$("#venus").click(function() {
 		$("#venusinvisible").toggleClass("show");
 	});
-
 });


### PR DESCRIPTION
Hey Dominic

This is the PR for my bug fixes for you; a few things to note;
1. the main issue was the order of the `<div>` tags; given you are stacking multiple `<div>` tags on top of another and want a click event for each tag then the order is really important. Previously you were starting with the sun object and then adding the planets afterward. This meant that only the last planet (i.e. Venus) was ever going to have a functioning click event. Reason being the venus `<div>` tag is the largest and covers the other tags making it impossible to click on them. 
Imagine a pyramid whereby the last planet pluto represents the base and the sun represents the peak of the pyramid. When taking a bird's eye view of the pyramid you see the sun/peak at the center of the pyramid and pluto/base as the widest. When you start with the sun tag first you are making the sun the base and the last planet the peak i.e. it's an upside-down pyramid and so only the base can be clicked since nothing else can be seen.
I hope that example above made things clearer but if not the important thing to note is that the biggest `<div>` tag needs to be rendered first while the smaller (sun) needs to be rendered last; you are working your way from the outside in which allows you to have click event handlers for each `<div>` tag.

2. the second smaller issue was the sun gif was still being rendered as a square but had a black background so was hard to see. I added a border-radius to the image tag to make it circle and it also required a position value so I have added that too

3. I added a venus information box (which I copied from Mercury) to aid with testing; you are now able to click on any of the planets and sun to view the information box